### PR TITLE
v0.3.0 - Introduce 'unique' option to remove duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 0.3.0
+- **Breaking change:** Introduce `unique` option to remove duplicate values. Previously, duplicate values were removed by default, but now it's "opt in" for performance reasons.
+
 ## 0.2.0
-- **Breaking Change:** Default export `truthyStringsKeys`.
+- **Breaking change:** Default export `truthyStringsKeys`.

--- a/README.md
+++ b/README.md
@@ -16,16 +16,19 @@ values into a simple string array.
 $ npm install truthy-strings-keys
 ```
 
-## Usage examples
+## Usage
+
+### `truthyStringsKeys( modifiers [, options] )`
 
 ```ts
-truthyStringsKeys([
+const modifiers = [
   'foo', [
     {
       bar: true,
       baz: null,
     },
   ],
+  'foo',
   'qux',
   [
     [
@@ -37,7 +40,12 @@ truthyStringsKeys([
       ],
     ],
   ],
-]);
+];
+
+truthyStringsKeys(modifiers);
+// ["foo", "bar", "foo", "qux", "garpley"]
+
+truthyStringsKeys(modifiers, { unique: true });
 // ["foo", "bar", "qux", "garpley"]
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truthy-strings-keys",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Resolves a simple string or a potentially deeply nested structure of primitive values into a simple string array.",
   "keywords": [
     "truthy",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -49,13 +49,6 @@ test('truthyStringsKeys returns a list of keys for which their values are truthy
 	)
 })
 
-test('truthyStringsKeys returns unique values', t => {
-	t.deepEqual(
-		truthyStringsKeys(['foo', 'bar', 'foo']),
-		['foo', 'bar'],
-	)
-})
-
 test('truthyStringsKeys omits falsey and non-string values', t => {
 	const values = [
 		'',
@@ -98,5 +91,28 @@ test('truthyStringsKeys returns a simple flat array from a complex nested struct
 		// tslint:disable-next-line:no-any
 		truthyStringsKeys(nested as any),
 		['foo', 'bar', 'qux', 'garpley'],
+	)
+})
+
+test('truthyStringsKeys returns unique values if { unique: true }', t => {
+	const modifiers = [
+		'foo',
+		'bar',
+		[
+			'foo',
+			'bar',
+			{
+				foo: true,
+				bar: true,
+			},
+		],
+	]
+	t.deepEqual(
+		truthyStringsKeys(modifiers),
+		['foo', 'bar', 'foo', 'bar', 'foo', 'bar'],
+	)
+	t.deepEqual(
+		truthyStringsKeys(modifiers, { unique: true }),
+		['foo', 'bar'],
 	)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,24 @@ import { Primitives } from './types'
  * primitive values into a simple string array.
  * @return Returns a simple string array of modifiers that passed resolution.
  */
-export default function truthyStringsKeys(modifiers?: Primitives): string[] {
-	return uniq(compact(isArray(modifiers)
-		? flatten(modifiers.map(m => truthyStringsKeys(m)))
+export default function truthyStringsKeys(
+	modifiers?: Primitives,
+	{
+		unique = false,
+	}: {
+		/**
+		 * Removes duplicate values.
+		 */
+		unique?: boolean
+	} = {},
+): string[] {
+	const result = compact(isArray(modifiers)
+		? flatten(modifiers.map(m => truthyStringsKeys(m, { unique })))
 		: isString(modifiers)
 			? modifiers.split(/\s+/)
 			: truthyKeys(modifiers as {}),
-	))
+	)
+	return unique ? uniq(result) : result
 }
 
 export function compact<T>(arr: T[]) {


### PR DESCRIPTION
## 0.3.0
- **Breaking change:** Introduce `unique` option to remove duplicate values. Previously, duplicate values were removed by default, but now it's "opt in" for performance reasons.